### PR TITLE
Center sprite in entity module snippet

### DIFF
--- a/bento-define-entity-module.sublime-snippet
+++ b/bento-define-entity-module.sublime-snippet
@@ -44,7 +44,7 @@ bento.define('${3}', [
             imageName: '${4}',
             frameCountX: 1,
             frameCountY: 1,
-            originRelative: new Vector2(0, 0),
+            originRelative: new Vector2(0.5, 0.5),
             animations: {
                 default: {
                     speed: 0,


### PR DESCRIPTION
0.5 is a sensible default for originRelative x/y, and it's the same as is used in Bento's Sprite snippet