### PR TITLE
Proposal: Rename 'behaviorComponent' to 'behavior'

### DIFF
--- a/bento-define-entity-module.sublime-snippet
+++ b/bento-define-entity-module.sublime-snippet
@@ -53,7 +53,7 @@ bento.define('${3}', [
             }
         });
         var behavior = {
-            name: '${5:behaviorComponent}',
+            name: '${5:behavior}',
             start: function (data) {},
             destroy: function (data) {},
             update: function (data) {},


### PR DESCRIPTION
I think this would be a better default for the following reasons:

- it's common for a component `name` field to be the same as the name of its local variable
- none of the other components have 'component' in the name. No info is lost by removing it