### PR TITLE
Auto-fill module path in define snippets

### DIFF
--- a/bento-define-component.sublime-snippet
+++ b/bento-define-component.sublime-snippet
@@ -8,7 +8,7 @@ ${2:ModuleName}({
     
 })
  */
-bento.define('${3}', [
+bento.define('${TM_FILEPATH/^(.+\/js\/)(.+)(\.js)/$2/}', [
     'bento',
     'bento/math/vector2',
     'bento/math/rectangle',
@@ -30,7 +30,7 @@ bento.define('${3}', [
         var viewport = Bento.getViewport();
         var entity;
         var component = {
-            name: '${4}',
+            name: '${3}',
             start: function (data) {},
             destroy: function (data) {},
             update: function (data) {},

--- a/bento-define-entity-module.sublime-snippet
+++ b/bento-define-entity-module.sublime-snippet
@@ -9,7 +9,7 @@ ${2:ModuleName}({
     position: new Vector2(0, 0)
 })
  */
-bento.define('${3}', [
+bento.define('${TM_FILEPATH/^(.+\/js\/)(.+)(\.js)/$2/}', [
     'bento',
     'bento/math/vector2',
     'bento/math/rectangle',
@@ -41,7 +41,7 @@ bento.define('${3}', [
         var viewport = Bento.getViewport();
         var position = settings.position;
         var sprite = new Sprite({
-            imageName: '${4}',
+            imageName: '${3}',
             frameCountX: 1,
             frameCountY: 1,
             originRelative: new Vector2(0.5, 0.5),
@@ -53,7 +53,7 @@ bento.define('${3}', [
             }
         });
         var behavior = {
-            name: '${5:behavior}',
+            name: '${4:behavior}',
             start: function (data) {},
             destroy: function (data) {},
             update: function (data) {},
@@ -61,7 +61,7 @@ bento.define('${3}', [
         };
         var entity = new Entity({
             z: 0,
-            name: '${6}',
+            name: '${5}',
             family: [''],
             position: position,
             updateWhenPaused: 0,

--- a/bento-define-screen.sublime-snippet
+++ b/bento-define-screen.sublime-snippet
@@ -4,7 +4,7 @@
 /**
  * ${1:Screen description}
  */
-bento.define('${2}', [
+bento.define('${TM_FILEPATH/^(.+\/js\/)(.+)(\.js)/$2/}', [
     'bento',
     'bento/math/vector2',
     'bento/math/rectangle',
@@ -35,7 +35,7 @@ bento.define('${2}', [
 ) {
     'use strict';
     var onShow = function (settings) {
-        ${3:/* Screen starts here */}
+        ${2:/* Screen starts here */}
     };
 
     return new Screen({


### PR DESCRIPTION
By performing some regex substitution on the current file path, we can get the snippets to fill in the module path for us.

i.e. you no longer have to manually fill out
```
bento.define('path/to/my/module',
```
as long as you have already saved the file somewhere in the `js` directory.

Unfortunately you still need to remember to update the path if you move the module somewhere else. (one solution to this could be ES6 modules, if we found a way to adopt them that satisfied everyone)