### PR TITLE
Another shot at fixing the `Foo.bar.baz()` snippets

### DIFF
--- a/bento.py
+++ b/bento.py
@@ -101,9 +101,10 @@ class CompletionListener(sublime_plugin.EventListener):
         # the thing you're typing may be inbetween other text, for example "if (...) {"
         lastWord = specialCharsExceptDots.split(lastWord)[-1]
         lastLetter = lastWord[-1]
+        lastWordWithDot = lastWord
 
         def addSnippet(snippet):
-            if not snippet[1].startswith(lastWord):
+            if not snippet[1].startswith(lastWordWithDot):
                 # the body of the snippet differs from what we typed so far
                 # so we don't want any correction for this snippet
                 out.append(snippet)
@@ -118,9 +119,7 @@ class CompletionListener(sublime_plugin.EventListener):
             else:
                 # otherwise ST will only replace whatever comes after the last dot
                 # so we have to trim the front of the snippet accordingly
-                lastDotPos = len(lastWord)
-                if lastLetter != '.':
-                    lastDotPos = lastWord.rfind('.')
+                lastDotPos = lastWordWithDot.rfind('.')
                 out.append([snippet[0], snippet[1][lastDotPos+1:]])
 
         if lastLetter == '.':

--- a/bento.py
+++ b/bento.py
@@ -69,7 +69,16 @@ def getFullPath(path):
     else:
         return fullPath
 
-# event listener when st presents completions
+specialChars = re.compile(r"\W")
+specialCharsExceptDots = re.compile(r"[^\w\.]")
+
+def countMatches(reg, s):
+    n = 0
+    for match in reg.finditer(s):
+        n += 1
+    return n
+
+# event listener when ST presents completions
 class CompletionListener(sublime_plugin.EventListener):
     def on_query_completions(self, view, prefix, locations):
         syntax = view.settings().get('syntax')
@@ -90,17 +99,21 @@ class CompletionListener(sublime_plugin.EventListener):
         lastWord = lastLine[0:column + 1]
         lastWord = lastWord.strip()
         # the thing you're typing may be inbetween other text, for example "if (...) {"
-        lastWordList = re.split('\[|\(|\{| |\:|\;|\,|\+|\-|\*|\/', lastWord)
-        lastWord = lastWordList[-1]
+        lastWord = specialCharsExceptDots.split(lastWord)[-1]
         lastLetter = lastWord[-1]
 
         def addSnippet(snippet):
-            # add snippet to the completions list
-            dotsInLastWord = lastWord.count('.') + lastLetter.count('.')
-            dotsInSnippet = snippet[1].count('.')
+            if not snippet[1].startswith(lastWord):
+                # the body of the snippet differs from what we typed so far
+                # so we don't want any correction for this snippet
+                out.append(snippet)
+                return
 
-            if dotsInSnippet <= 1 or dotsInLastWord == 0 or dotsInSnippet == dotsInLastWord:
-                # in these cases, ST will correctly replace the whole word
+            specialCharsInLastWord = countMatches(specialChars, lastWord) + lastLetter.count('.')
+            specialCharsInSnippetName = countMatches(specialChars, snippet[0].split('\t')[0])
+
+            if specialCharsInSnippetName == specialCharsInLastWord:
+                # in this case ST will correctly replace the whole word
                 out.append(snippet)
             else:
                 # otherwise ST will only replace whatever comes after the last dot


### PR DESCRIPTION
Turns out it's not just dots that affects this, but all non-word characters. Therefore snippets with brackets in them would still mess things up.

Also, whether sublime replaces the whole word (including dots) depends on how much of the snippet *trigger* we typed, not how much of the body. So this could lead to incorrect results sometimes.

On a similar note, if the body is totally different to the trigger, I don't try to correct it anymore.